### PR TITLE
lastStatusの取得

### DIFF
--- a/chInChOut.py
+++ b/chInChOut.py
@@ -1,8 +1,31 @@
-import ui
+import ui, os
 from datetime import datetime
 
 chkin = False
 
+master_today = datetime.today()
+master_str_today = f'{master_today:%Y-%m-%d}'
+master_now = datetime.now()
+master_str_now = f'{master_now:%Y-%m-%d %H:%M:%S}'
+master_path = 'log/' + master_str_today + '.csv'
+
+if os.path.exists(master_path):
+	with open(master_path, encoding='utf-8') as f:
+		for row in f:
+			lastRow = row.rstrip()
+		columns = lastRow.split(',')
+		lastTime = columns[0]
+		status = columns[1]
+	
+	label = sender.superview['label1']
+	text = 'last status\n' + status + 'at ' + lastTime
+	label.text = text
+
+	if status == 'check_in':
+		chkin = False
+	elif status == 'check_out':
+		chkin = True
+				
 
 def checkin(sender):
 	global chkin


### PR DESCRIPTION
#### 変更内容
lastStatusを起動時に取得し、再起動した場合にもチェックインチェックアウト処理が正しく行われるようにした。

#### 背景
チェックイン後、プログラムを再起動すると、再度チェックインしないとチェックアウトが記録できなかったため。